### PR TITLE
Make thread liveness checks hub-agnostic (prep for native hub)

### DIFF
--- a/faucet/valve_ryuapp.py
+++ b/faucet/valve_ryuapp.py
@@ -29,7 +29,7 @@ from os_ken.controller.handler import set_ev_cls
 from os_ken.lib import hub
 
 from faucet import valve_of
-from faucet.valve_util import dpid_log, get_logger, get_setting
+from faucet.valve_util import dpid_log, get_logger, get_setting, thread_is_dead
 
 
 class ValveDeadThreadException(Exception):
@@ -79,7 +79,7 @@ class OSKenAppBase(app_manager.OSKenApp):
 
     def _check_thread_exception(self):
         """Check for a dead thread and cause/log an exception."""
-        dead_threads = [thread for thread in self._get_threads() if thread.dead]
+        dead_threads = [t for t in self._get_threads() if thread_is_dead(t)]
         if dead_threads:
             for thread in dead_threads:
                 thread_name = getattr(thread, "name", "unknown")

--- a/faucet/valve_util.py
+++ b/faucet/valve_util.py
@@ -48,6 +48,18 @@ def utf8_decode(msg_str):
     return msg_str.decode("utf-8", errors="replace")
 
 
+def thread_is_dead(thread):
+    """Return True if a hub thread has terminated.
+
+    Bridges the os-ken eventlet ``GreenThread`` (``.dead`` property) and
+    the os-ken native ``HubThread`` (``threading.Thread.is_alive``) APIs
+    so callers don't need to know which hub is in use.
+    """
+    if hasattr(thread, "dead"):
+        return bool(thread.dead)
+    return not thread.is_alive()
+
+
 def get_sys_prefix():
     """Returns an additional prefix for log and configuration files when used in
     a virtual environment"""

--- a/tests/unit/gauge/test_gauge.py
+++ b/tests/unit/gauge/test_gauge.py
@@ -397,7 +397,7 @@ class GaugeThreadPollerTest(unittest.TestCase):  # pytype: disable=module-attr
         poller_thread = self.poller.thread
         hub.sleep(self.interval + 1)
         self.assertTrue(self.send_called)
-        self.assertFalse(poller_thread.dead)
+        self.assertFalse(valve_util.thread_is_dead(poller_thread))
 
     def test_stop(self):
         """Check if a poller can be stopped"""
@@ -409,7 +409,7 @@ class GaugeThreadPollerTest(unittest.TestCase):  # pytype: disable=module-attr
         hub.sleep(self.interval + 1)
 
         self.assertFalse(self.send_called)
-        self.assertTrue(poller_thread.dead)
+        self.assertTrue(valve_util.thread_is_dead(poller_thread))
 
     def test_active(self):
         """Check if active reflects the state of the poller"""


### PR DESCRIPTION
## Summary

- Add `valve_util.thread_is_dead(thread)` that probes `.dead` first and falls back to `not is_alive()`, so callers don't have to know whether they're on os-ken's eventlet `GreenThread` or native `HubThread` (`threading.Thread` subclass).
- Route `valve_ryuapp._check_thread_exception` and the two `GaugeThreadPollerTest` asserts (`test_start`, `test_stop`) through it.
- No behavioural change on the eventlet hub.

## Why this is *only* a prep PR

A flip to `OSKEN_HUB_TYPE=native` is still blocked on three things this PR intentionally does not touch:

1. **`faucet/faucet.py:22-25`** does `import eventlet; eventlet.monkey_patch()` unconditionally. Together with the `OSKEN_HUB_TYPE=eventlet` pin from #399 (in `__main__.py` and the test runners), this is what keeps the hub on eventlet today. Removing it is the bulk of the migration work.
2. **`faucet/gauge_pollers.py:173-178`** relies on `hub.kill(self.thread)` to stop the polling loop. `hub.kill` is a documented no-op under the native hub (*"there is no safe and reliable way to force stopping a thread in Python"*), so the loop has to learn to bail on a `threading.Event` (or similar) before native works end-to-end. (I prototyped this with `hub.Event` and discovered os-ken's `hub.Event.wait(timeout=)` doesn't actually time out under native — `threading.Event` directly is the workable substitute, but it's a bigger refactor than this PR wants.)
3. **`c65beka` and `c65chewie`** import `eventlet.queue`, `eventlet.GreenPool`, `eventlet.green.socket` etc. directly. Until those (or their replacements) drop eventlet, faucet's BGP and 802.1x paths won't work on a native-only process even if everything else is clean.

So: this PR is a small, safe step that knocks out one easy item on the list. The remaining work belongs in follow-up PRs.

## Test plan

- [x] `OSKEN_HUB_TYPE=eventlet python -m unittest test_gauge` — 15/15 pass
- [x] pylint `valve_util.py` / `valve_ryuapp.py` rating still ≥ 9.50 (locally 9.90)
- [x] `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)