### PR TITLE
clib/_ofctl: catch ValueError on non-JSON REST replies

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -861,7 +861,10 @@ class FaucetTestBase(unittest.TestCase):
             params = {}
         try:
             ofctl_result = requests.get(req, params=params).json()
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, ValueError):
+            # ValueError covers JSONDecodeError when the REST endpoint
+            # is up but answers with an empty/non-JSON body (e.g. during
+            # osken-manager startup). _ofctl_get retries on None.
             return None
         return ofctl_result
 


### PR DESCRIPTION
## Summary
- `_ofctl` only caught `ConnectionError`; if the osken-manager REST endpoint was up but momentarily answered with an empty/non-JSON body, `requests.get(...).json()` raised `JSONDecodeError` and bypassed the existing retry loop in `_ofctl_get`.
- Catching `ValueError` (parent of `JSONDecodeError`) in `_ofctl` lets `_ofctl_get`'s retry loop kick in normally, fixing flaky setUp failures like `FaucetSingleMCLAGComplexTest.test_lacp_port_change`.

## Test plan
- [ ] Integration tests on this branch pass.
- [ ] Re-running PR #391's pull_request build (which merges with main) no longer trips the `JSONDecodeError` flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)