### PR TITLE
faucet_config_applied: signal after barrier-acked drain, not enqueue

### DIFF
--- a/clib/valve_test_lib.py
+++ b/clib/valve_test_lib.py
@@ -813,10 +813,15 @@ class ValveTestBases:
                 self._verify_redundant_safe_offset_ofmsgs(ofmsgs, dp_id, offset)
             return final_ofmsgs
 
-        def send_flows_to_dp_by_id(self, valve, flows):
+        def send_flows_to_dp_by_id(self, valve, flows, on_complete=None):
             """Callback function for ValvesManager to simulate sending flows to a DP"""
             flows = valve.prepare_send_flows(flows)
             self.last_flows_to_dp[valve.dp.dp_id] = flows
+            if on_complete is not None:
+                # Real send path defers this to the per-DP sender thread
+                # once the trailing barrier acks; the unit harness has
+                # no wire, so signal completion synchronously.
+                on_complete()
 
         def configure_network(self):
             """Creates the FakeOFNetwork"""

--- a/faucet/faucet.py
+++ b/faucet/faucet.py
@@ -202,13 +202,17 @@ class Faucet(OSKenAppBase):
         )
 
     @kill_on_exception(exc_logname)
-    def _send_flow_msgs(self, valve, flow_msgs, ryu_dp=None):
+    def _send_flow_msgs(self, valve, flow_msgs, ryu_dp=None, on_complete=None):
         """Send OpenFlow messages to a connected datapath.
 
         Args:
             Valve instance or None.
             flow_msgs (list): OpenFlow messages to send.
             ryu_dp: Override datapath from DPSet.
+            on_complete: callback fired from the sender thread once the
+                batch's trailing barrier is acked. Skipped when the DP
+                is offline (the caller's config_applied flag stays
+                False, matching the old dyn_running gate).
         """
         if ryu_dp is None:
             ryu_dp = self.dpset.get(valve.dp.dp_id)
@@ -216,7 +220,11 @@ class Faucet(OSKenAppBase):
             valve.logger.error("send_flow_msgs: DP not up")
             return
         valve.send_flows(
-            ryu_dp, flow_msgs, time.time(), valves_manager=self.valves_manager
+            ryu_dp,
+            flow_msgs,
+            time.time(),
+            valves_manager=self.valves_manager,
+            on_complete=on_complete,
         )
 
     def _get_valve(self, ryu_event, require_running=False):

--- a/faucet/valve.py
+++ b/faucet/valve.py
@@ -1835,7 +1835,7 @@ class Valve:
         self.recent_ofmsgs.extend(reordered_flow_msgs)
         return reordered_flow_msgs
 
-    def send_flows(self, ryu_dp, flow_msgs, now, valves_manager=None):
+    def send_flows(self, ryu_dp, flow_msgs, now, valves_manager=None, on_complete=None):
         """Send flows to datapath (or disconnect an OF session).
 
         Args:
@@ -1846,6 +1846,9 @@ class Valve:
                 the barrier-aware sender thread for this datapath.
                 Otherwise falls back to inline send (used by tests that
                 drive prepare_send_flows directly).
+            on_complete: callable invoked from the sender thread after
+                the batch's trailing barrier has been acked. Only
+                meaningful when ``valves_manager`` is provided.
         """
         if flow_msgs is None:
             self.datapath_disconnect(now)
@@ -1855,7 +1858,9 @@ class Valve:
             return
         prepared = self.prepare_send_flows(flow_msgs)
         if valves_manager is not None:
-            valves_manager.submit_to_sender(self, ryu_dp, prepared)
+            valves_manager.submit_to_sender(
+                self, ryu_dp, prepared, on_complete=on_complete
+            )
             return
         for flow_msg in prepared:
             flow_msg.datapath = ryu_dp

--- a/faucet/valve_send.py
+++ b/faucet/valve_send.py
@@ -28,6 +28,11 @@ from os_ken.ofproto import ofproto_v1_3_parser as parser
 BARRIER_TIMEOUT = 5.0
 
 
+def _ends_with_barrier(batch):
+    """True iff ``batch`` is non-empty and ends with an OFPBarrierRequest."""
+    return bool(batch) and isinstance(batch[-1], parser.OFPBarrierRequest)
+
+
 class BarrierAwareSender:
     """Per-datapath worker that pushes prepared message batches in order
     and waits for OFPBarrierReply before continuing past each barrier."""
@@ -44,7 +49,8 @@ class BarrierAwareSender:
         self.valves_manager = valves_manager
         self.logger = logger
         self.barrier_timeout = barrier_timeout
-        self._queue: "queue.Queue[list]" = queue.Queue()
+        # Items are either (batch, on_complete) tuples or _stop_sentinel.
+        self._queue: "queue.Queue" = queue.Queue()
         self._stop_sentinel = object()
         self._stopped = threading.Event()
         self._thread = threading.Thread(
@@ -54,12 +60,22 @@ class BarrierAwareSender:
         )
         self._thread.start()
 
-    def submit(self, ofmsgs):
-        """Enqueue an already-prepared (reordered) ofmsg batch."""
+    def submit(self, ofmsgs, on_complete=None):
+        """Enqueue an already-prepared (reordered) ofmsg batch.
+
+        ``on_complete`` (if given) is invoked from the worker thread once
+        the batch has fully drained -- including the OFPBarrierReply for
+        the final barrier. If the batch as submitted has no trailing
+        barrier, the worker appends one before invoking the callback so
+        completion truly means the switch has acked the last message.
+        The callback is *not* invoked if the channel is torn down
+        mid-batch (sender exits and reconnect re-pushes config).
+        """
         if self._stopped.is_set():
             return
-        if ofmsgs:
-            self._queue.put(list(ofmsgs))
+        if not ofmsgs and on_complete is None:
+            return
+        self._queue.put((list(ofmsgs), on_complete))
 
     def stop(self):
         """Signal the worker to drain and exit. Idempotent."""
@@ -71,11 +87,22 @@ class BarrierAwareSender:
     def _run(self):
         try:
             while True:
-                batch = self._queue.get()
-                if batch is self._stop_sentinel:
+                item = self._queue.get()
+                if item is self._stop_sentinel:
                     return
+                batch, on_complete = item
+                if on_complete is not None and not _ends_with_barrier(batch):
+                    batch.append(parser.OFPBarrierRequest(None))
                 if not self._send_batch(batch):
                     return
+                if on_complete is not None:
+                    try:
+                        on_complete()
+                    except Exception:  # pylint: disable=broad-except
+                        self.logger.exception(
+                            "on_complete callback for %016x raised",
+                            self.dp_id,
+                        )
         except Exception:  # pylint: disable=broad-except
             self.logger.exception("sender thread for %016x crashed", self.dp_id)
 

--- a/faucet/valves_manager.py
+++ b/faucet/valves_manager.py
@@ -19,6 +19,7 @@
 
 import threading
 from collections import defaultdict
+from functools import partial
 
 from faucet.conf import InvalidConfigError
 from faucet.config_parser_util import config_changed, CONFIG_HASH_FUNC
@@ -121,6 +122,10 @@ class ValvesManager:
         # send and stopped when the datapath disconnects.
         self._senders_lock = threading.Lock()
         self._senders = {}
+        # _mark_dp_config_applied runs on the sender thread but mutates
+        # the same dict touched by reset/datapath_connect on the event
+        # loop, so guard the read-modify-set with a lock.
+        self._config_applied_lock = threading.Lock()
 
     def update_dp_live_time(self, now):
         """
@@ -311,15 +316,18 @@ class ValvesManager:
         if new_dps is None:
             return False
         deleted_dpids = set(self.valves) - {dp.dp_id for dp in new_dps}
-        sent = {}
         for new_dp in new_dps:
             dp_id = new_dp.dp_id
             if dp_id in self.valves:
                 self.logger.info("Reconfiguring existing datapath %s", dpid_log(dp_id))
                 valve = self.valves[dp_id]
                 ofmsgs = valve.reload_config(now, new_dp, list(self.valves.values()))
-                self.send_flows_to_dp_by_id(valve, ofmsgs)
-                sent[dp_id] = valve.dp.dyn_running
+                # Mark config_applied[dp_id] only after the per-DP sender
+                # has drained (final barrier acked). For offline DPs the
+                # send path bails out so the callback never fires and the
+                # flag stays False -- matching the prior dyn_running gate.
+                on_complete = partial(self._mark_dp_config_applied, dp_id)
+                self.send_flows_to_dp_by_id(valve, ofmsgs, on_complete=on_complete)
             else:
                 self.logger.info("Add new datapath %s", dpid_log(new_dp.dp_id))
                 valve = self.new_valve(new_dp)
@@ -334,8 +342,21 @@ class ValvesManager:
                 del self.valves[deleted_dp]
         self.bgp.reset(self.valves)
         self.dot1x.reset(self.valves)
-        self.update_config_applied(sent)
+        # Recompute the fraction now that self.valves has settled. Any
+        # on_complete that fired during the loop saw a partial valve
+        # set; a final pass over the full set yields the right
+        # denominator (and accounts for new/offline DPs whose callback
+        # never runs).
+        self.update_config_applied()
         return True
+
+    def _mark_dp_config_applied(self, dp_id):
+        """Record that ``dp_id`` has acked its config-apply batch.
+
+        Invoked from the per-DP sender thread once the trailing barrier
+        has been acknowledged.
+        """
+        self.update_config_applied({dp_id: True})
 
     def load_configs(self, now, new_config_file, delete_dp=None):
         """Load/apply new config to all Valves."""
@@ -450,17 +471,25 @@ class ValvesManager:
             valve.update_metrics(now, pkt_meta.port, rate_limited=True)
 
     def update_config_applied(self, sent=None, reset=False):
-        """Update faucet_config_applied from {dpid: sent} dict,
-        defining applied == sent == enqueued via Ryu"""
-        if reset:
-            self.config_applied = defaultdict(bool)
-        if sent:
-            self.config_applied.update(sent)
-        count = float(len(self.valves))
-        configured = sum(
-            (1 if self.config_applied[dp_id] else 0) for dp_id in self.valves
-        )
-        fraction = configured / count if count > 0 else 0
+        """Update faucet_config_applied from {dpid: applied} dict.
+
+        ``applied == True`` means the DP has acked its config-apply
+        batch (including the trailing barrier the per-DP sender appends
+        when needed). The metric is the fraction of DPs that have
+        acked, so the test fixture can use ``faucet_config_applied=1``
+        as a real synchronisation point rather than a "messages
+        enqueued" signal.
+        """
+        with self._config_applied_lock:
+            if reset:
+                self.config_applied = defaultdict(bool)
+            if sent:
+                self.config_applied.update(sent)
+            count = float(len(self.valves))
+            configured = sum(
+                (1 if self.config_applied[dp_id] else 0) for dp_id in self.valves
+            )
+            fraction = configured / count if count > 0 else 0
         self.metrics.faucet_config_applied.set(fraction)
 
     def datapath_connect(self, now, valve, discovered_up_ports):
@@ -507,14 +536,18 @@ class ValvesManager:
         for event in waiters.values():
             event.set()
 
-    def submit_to_sender(self, valve, ryu_dp, ofmsgs):
+    def submit_to_sender(self, valve, ryu_dp, ofmsgs, on_complete=None):
         """Hand a prepared ofmsg batch to the per-DP sender thread.
 
         Lazily creates the sender on first use. Subsequent calls reuse
         it; on reconnect the dp_id remains the same so the existing
         thread keeps draining.
+
+        ``on_complete``, if given, runs on the sender thread after the
+        batch has been acked by the switch (the sender appends a final
+        barrier when needed so completion really means committed).
         """
-        if not ofmsgs:
+        if not ofmsgs and on_complete is None:
             return
         dp_id = ryu_dp.id
         with self._senders_lock:
@@ -526,7 +559,7 @@ class ValvesManager:
                     sender.stop()
                 sender = BarrierAwareSender(ryu_dp, self, valve.logger.logger)
                 self._senders[dp_id] = sender
-        sender.submit(ofmsgs)
+        sender.submit(ofmsgs, on_complete=on_complete)
 
     def stop_sender(self, dp_id):
         """Stop the sender for a datapath that has disconnected and

--- a/tests/unit/faucet/test_valve_send.py
+++ b/tests/unit/faucet/test_valve_send.py
@@ -257,6 +257,83 @@ class BarrierAwareSenderTestCase(unittest.TestCase):
         self.assertEqual(len(ryu_dp.sent), 5)
         self.assertEqual(dict(manager._barrier_waiters), {})
 
+    def test_on_complete_fires_after_trailing_barrier(self):
+        """on_complete must run only after the batch's trailing barrier
+        is acked. If the caller didn't add a barrier, the sender adds
+        one so completion really means "switch acked the last message"."""
+        ryu_dp = FakeRyuDp(0x5678)
+        manager = _make_manager()
+        sender = self._spawn(ryu_dp, manager)
+        done = threading.Event()
+        sender.submit([_flow(), _flow()], on_complete=done.set)
+
+        # Sender appends a barrier because the batch lacks one. The
+        # callback must NOT have fired before the barrier is acked.
+        self._wait_for_barrier(ryu_dp)
+        time.sleep(0.05)
+        self.assertFalse(
+            done.is_set(),
+            "on_complete fired before barrier reply",
+        )
+        with ryu_dp._send_lock:
+            barrier_xid = next(
+                m.xid
+                for m in ryu_dp.sent
+                if isinstance(m, valve_of.parser.OFPBarrierRequest)
+            )
+        manager.complete_barrier(ryu_dp.id, barrier_xid)
+        self.assertTrue(done.wait(1.0), "on_complete did not fire after ack")
+        with ryu_dp._send_lock:
+            kinds = [type(m).__name__ for m in ryu_dp.sent]
+        self.assertEqual(
+            kinds,
+            ["OFPFlowMod", "OFPFlowMod", "OFPBarrierRequest"],
+            "expected sender to append a final barrier",
+        )
+
+    def test_on_complete_does_not_double_barrier(self):
+        """If the caller-supplied batch already ends with a barrier, the
+        sender must not append a second one."""
+        ryu_dp = FakeRyuDp(0x9ABC)
+        manager = _make_manager()
+        sender = self._spawn(ryu_dp, manager)
+        done = threading.Event()
+        sender.submit([_flow(), valve_of.barrier()], on_complete=done.set)
+        self._wait_for_barrier(ryu_dp)
+
+        with ryu_dp._send_lock:
+            barriers = [
+                m
+                for m in ryu_dp.sent
+                if isinstance(m, valve_of.parser.OFPBarrierRequest)
+            ]
+        self.assertEqual(len(barriers), 1, "sender double-added a barrier")
+        manager.complete_barrier(ryu_dp.id, barriers[0].xid)
+        self.assertTrue(done.wait(1.0), "on_complete did not fire after ack")
+
+    def test_on_complete_skipped_on_channel_drop(self):
+        """If the channel is torn down mid-batch, on_complete must not
+        fire (reconnect will re-push and re-register a callback)."""
+        ryu_dp = FakeRyuDp(0xDEAD0001)
+        manager = _make_manager()
+        sender = self._spawn(ryu_dp, manager, timeout=0.1)
+        fired = threading.Event()
+        sender.submit(
+            [_flow(), valve_of.barrier(), _flow()],
+            on_complete=fired.set,
+        )
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not ryu_dp.closed:
+            time.sleep(0.02)
+        self.assertTrue(ryu_dp.closed, "expected channel close on timeout")
+        # Give the worker a moment to (incorrectly) run the callback.
+        time.sleep(0.1)
+        self.assertFalse(
+            fired.is_set(),
+            "on_complete fired despite barrier-timeout channel drop",
+        )
+
 
 class BarrierWaiterRegistryTestCase(unittest.TestCase):
     """Smaller direct exercise of the ValvesManager waiter API."""


### PR DESCRIPTION
## Summary

`faucet_config_applied=1` previously meant "ofmsgs have been handed to the per-DP sender thread", not "the switch has acked them". The integration test fixture treats it as the latter, so warm-reload tests can race actual flow installation. The most recent symptom was the shard-9 flake on PR #403 — `FaucetSingleStackStringOfDPExtLoopProtUntaggedTest.test_untagged` saw 0 broadcast packets immediately after `_mark_external`'s warm reload.

This change threads an `on_complete` callback through `send_flows_to_dp_by_id` → `Valve.send_flows` → `ValvesManager.submit_to_sender` → `BarrierAwareSender.submit`. The sender fires the callback only after the batch's trailing `OFPBarrierReply` lands, appending a final barrier when the caller didn't supply one. `_apply_configs` registers a per-DP callback that flips `config_applied[dp_id]` to True post-ack, so the gauge rises from 0.0 to 1.0 as DPs actually drain. Channel teardown skips the callback (reconnect re-pushes config and re-registers).

`config_applied` is now mutated from sender threads, so the read-modify-set is locked. A final `update_config_applied()` after the loop recomputes the fraction with the settled valve set, which matters for the in-memory test fixture (synchronous `on_complete`).

## Test plan
- [x] `tests/unit/faucet/test_valve_send.py` — adds three cases (callback fires after trailing-barrier ack; no double barriers; suppressed on barrier timeout) plus retains existing coverage. All 11 sender tests pass.
- [x] `tests/unit/faucet/test_valve.py` (111 tests) and `test_valve_config.py` (71 tests) pass with the updated `valve_test_lib` fixture.
- [ ] Integration tests pass on CI.
- [ ] PR #403's `pull_request` build (which merges with main) stops flaking on `test_untagged` post-reload broadcast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)