### PR TITLE
clib: fix two flakes exposed by faster controller-startup waits.

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -992,9 +992,11 @@ class FaucetTestBase(unittest.TestCase):
         for _, debug_log in ofchannel_logs:
             for _ in range(60 * 4):
                 if os.path.exists(debug_log) and os.path.getsize(debug_log) > 0:
-                    return True
+                    break
                 time.sleep(0.25)
-        return False
+            else:
+                return False
+        return True
 
     def verify_no_exception(self, exception_log_name):
         if not os.path.exists(exception_log_name):
@@ -1525,8 +1527,13 @@ dbs:
                 return False
         return True
 
-    def scrape_port_counters(self, ports, port_vars):
-        """Scrape Gauge for list of ports and list of variables."""
+    def scrape_port_counters(self, ports, port_vars, assert_present=True):
+        """Scrape Gauge for list of ports and list of variables.
+
+        If ``assert_present`` is False, missing counters / speed / state values
+        are returned as None instead of failing the test — callers use this to
+        poll until the gauge has completed its first watcher cycle.
+        """
         port_counters = {port: {} for port in ports}
         for port in ports:
             port_labels = self.port_labels(self.port_map[port])
@@ -1538,7 +1545,10 @@ dbs:
                     dpid=True,
                     retries=3,
                 )
-                self.assertIsNotNone(val, "%s missing for port %s" % (port_var, port))
+                if assert_present:
+                    self.assertIsNotNone(
+                        val, "%s missing for port %s" % (port_var, port)
+                    )
                 port_counters[port][port_var] = val
             # Require port to be up and reporting non-zero speed.
             speed = self.scrape_prometheus_var(
@@ -1547,20 +1557,22 @@ dbs:
                 controller=self.gauge_controller.name,
                 retries=3,
             )
-            self.assertTrue(
-                speed and speed > 0,
-                msg="%s %s: %s" % ("of_port_curr_speed", port_labels, speed),
-            )
+            if assert_present:
+                self.assertTrue(
+                    speed and speed > 0,
+                    msg="%s %s: %s" % ("of_port_curr_speed", port_labels, speed),
+                )
             state = self.scrape_prometheus_var(
                 "of_port_state",
                 labels=port_labels,
                 controller=self.gauge_controller.name,
                 retries=3,
             )
-            self.assertFalse(
-                state & ofp.OFPPS_LINK_DOWN,
-                msg="%s %s: %s" % ("of_port_state", port_labels, state),
-            )
+            if assert_present:
+                self.assertFalse(
+                    state & ofp.OFPPS_LINK_DOWN,
+                    msg="%s %s: %s" % ("of_port_state", port_labels, state),
+                )
         return port_counters
 
     def wait_ports_updating(self, ports, port_vars, stimulate_counters_func=None):
@@ -1568,8 +1580,26 @@ dbs:
         if stimulate_counters_func is None:
             stimulate_counters_func = self.ping_all_when_learned
         ports_not_updated = set(ports)
-        first_counters = self.scrape_port_counters(ports_not_updated, port_vars)
         start_time = time.time()
+
+        # The gauge watcher can take up to one poll interval after the DP comes
+        # up to scrape port stats and export them to Prometheus. Wait for the
+        # baseline counters to appear before requiring them to increase, so the
+        # initial scrape doesn't race the watcher's first poll.
+        first_counters = self.scrape_port_counters(
+            ports_not_updated, port_vars, assert_present=False
+        )
+        for _ in range(self.DB_TIMEOUT * 3):
+            if all(
+                first_counters[port].get(var) is not None
+                for port in ports_not_updated
+                for var in port_vars
+            ):
+                break
+            time.sleep(1)
+            first_counters = self.scrape_port_counters(
+                ports_not_updated, port_vars, assert_present=False
+            )
 
         for _ in range(self.DB_TIMEOUT * 3):
             stimulate_counters_func()


### PR DESCRIPTION
_wait_debug_log used "return True" inside its inner loop, so since 2017 it returned as soon as the *first* switch's ofchannel log appeared — not once every switch had, despite what the docstring said. The previous slow listen_port (lsof) hid this; now that listen_port uses ss and the poll loops are sub-second, start_net can return before laggard DPs finish their OF handshake, causing multi-DP tests like FaucetStackStringOfDPUntaggedTest to send LLDP before the bridge-local catch flow is installed on every DP.

scrape_port_counters hard-asserted each Prometheus var was present after ~2s of internal retries, but wait_dp_status only confirms the DP is connected — not that the gauge has completed its first port_stats poll (up to 5s in FaucetUntaggedPrometheusGaugeTest). Add an assert_present flag and have wait_ports_updating poll tolerantly until the baseline counters appear before requiring them to increase.