### PR TITLE
clib: avoid TypeError when gauge baseline counter is still None

### DIFF
--- a/clib/mininet_test_base.py
+++ b/clib/mininet_test_base.py
@@ -1608,7 +1608,16 @@ dbs:
             for port in ports_not_updated:
                 first = first_counters[port]
                 now = now_counters[port]
-                not_updated = [var for var, val in now.items() if val <= first[var]]
+                # first_counters is scraped tolerantly (assert_present=False), so a
+                # baseline var may still be None if the gauge watcher hadn't exported
+                # it before the wait loop above timed out. Treat a missing baseline as
+                # "not updated" so we keep polling and eventually return False (a clean
+                # caller-side failure) rather than raising TypeError on None <= int.
+                not_updated = [
+                    var
+                    for var, val in now.items()
+                    if first[var] is None or val <= first[var]
+                ]
                 if not_updated:
                     break
                 updated_ports.add(port)


### PR DESCRIPTION
## Background

Shard 9 of the integration tests flaked on `FaucetUntaggedPrometheusGaugeTest.test_untagged`:
- the first scrape raced the gauge watcher's first poll (`of_port_tx_bytes missing for port port_3`), and
- the retry then hit `FileExistsError` in `_tmpdir_name`, so retries could never recover.

Both root causes are already fixed in `main` (`fee3af1e` rmtree-on-retry, `f2ab42be` tolerant baseline poll). This PR closes a **latent defect introduced by that fix**.

## Problem

`wait_ports_updating` now scrapes its baseline counters tolerantly (`assert_present=False`), so `first_counters[port][var]` can still be `None` if the gauge watcher hasn't exported a stat before the 15s (`DB_TIMEOUT * 3`) wait loop times out. The subsequent increase check did:

```python
not_updated = [var for var, val in now.items() if val <= first[var]]
```

`now[var]` is always a real int (it's asserted present), but `first[var]` can be `None`, so `int <= None` raises `TypeError` and crashes the test — in exactly the slow-gauge scenario the flake fix was meant to tolerate. Instead of the caller's clean `"Gauge Prometheus port counters not increasing"` failure, shard 9 would go red with a confusing traceback.

## Fix

Treat a missing baseline as "not updated" so the port stays in the polling set and `wait_ports_updating` returns `False` cleanly (which the caller already handles as a clear failure) rather than throwing.

## Testing

- `python -c "import ast; ast.parse(...)"` — syntax OK
- `black --check clib/mininet_test_base.py` — unchanged

The full integration suite needs the privileged `c65sdn/test-base` Docker/mininet/OVS environment and was not run locally; CI will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)